### PR TITLE
Test/saved and poem display

### DIFF
--- a/cypress/integration/home-page.spec.js
+++ b/cypress/integration/home-page.spec.js
@@ -74,12 +74,24 @@ context('Home Page', () => {
       cy.get('div[class=Chord]').contains('notes')
     })
 
-    it.only('should play the chord when it is clicked', () => {
+    it('should play the chord when it is clicked', () => {
       cy.get('button[class=new-song-button]').click()
       cy.get('div[class="Progression"]')
       cy.get('div[class=Chord]').contains('C').click()
       cy.window().should('have.attr', 'Sound')
       cy.window('Howl').trigger('init')
+    })
+
+    it('should ONLY play chords from the selected key signature', () => {
+      cy.get('select[id=key]')
+      .select('D')
+      cy.get('div[class=qual-container]')
+      .find('label')
+      .contains('Minor')
+      .click()
+      cy.get('button[class=new-song-button]').click()
+      cy.get('div[class="Progression"]')
+      cy.get('div[class=Chord]').click({multiple: true})
     })
   })
 })

--- a/cypress/integration/home-page.spec.js
+++ b/cypress/integration/home-page.spec.js
@@ -22,8 +22,6 @@ context('Home Page', () => {
       cy.get('div[class=Song]')
       .find('h1')
       .contains('Let\'s get started!')
-    })
-    it('should NOT display a song on page load', () => {
       cy.get('div[class=Song]')
       .find('p')
       .contains('Choose "Major" or "Minor".')
@@ -44,11 +42,6 @@ context('Home Page', () => {
       .find('label')
       .contains('Minor')
       .click()
-    })
-    it('should display a new song when "New Song" is clicked', () => {
-      cy.get('div[class=Header]')
-        .find('div[class=NavBar]')
-      cy.get('button[class=new-song-button]').click()
     })
     it('should display a new song when "New Song" is clicked', () => {
       cy.get('div[class=Header]')

--- a/cypress/integration/poem-page.spec.js
+++ b/cypress/integration/poem-page.spec.js
@@ -1,0 +1,14 @@
+context('Poem page', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/')
+  })
+
+  describe('Poem page', () => {
+    it('should display the full poem when user clicks "see full poem"', () => {
+      cy.get('button[class=new-song-button]').click()
+      cy.get('div[class=Lyrics]').find('a').contains('see full poem').click()
+      cy.get('div[class=poem-display]').find('p').should('exist')
+      cy.get('div[class=Lyrics]').find('a').contains('Back to Song').click()
+    })
+  })
+})

--- a/cypress/integration/saved-songs.spec.js
+++ b/cypress/integration/saved-songs.spec.js
@@ -1,0 +1,35 @@
+context('Saved Songs', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/')
+  })
+
+  describe('Header', () => {
+    it('should add a song to "Saved Songs" when "Save Song" is clicked', () => {
+      cy.get('div[class=Header]')
+        .find('div[class=NavBar]')
+      cy.get('button[class=new-song-button]').click()
+      cy.wait(300)
+      cy.get('button[class=save-song]').click()
+    })
+  })
+  it('should display saved songs on separate page', () => {
+      cy.get('div[class=Header]')
+        .find('div[class=NavBar]')
+      cy.get('button[class=new-song-button]').click()
+      cy.wait(300)
+      cy.get('button[class=save-song]').click()
+      cy.get('button[class=new-song-button]').click()
+      cy.wait(300)
+      cy.get('button[class=save-song]').click()
+      cy.get('a').contains('Saved').click()
+      cy.get('div[class=SavedSong]').should('have.length', 2)
+    })
+    it.only('should allow a user to view a saved song on the main display', () => {
+      cy.get('button[class=new-song-button]').click()
+      cy.wait(300)
+      cy.get('button[class=save-song]').click()
+      cy.get('a').contains('Saved').click()
+      cy.get('div[class=SavedSong]').find('button[class="showsong-button"]').click()
+      cy.get('div[class=Song]').find('div[class=Lyrics]').contains('see full poem')
+    })
+  })


### PR DESCRIPTION
### Is this PR a feature/fix/refactor/test?
Test

### What does this PR do?
Adds two testing files to test the saved songs display and the full poem display.

### Where should the reviewer start?
`cypress/poem-page.spec.js`
`cypress/saved-songs.spec.js`

### How is this tested?
With the application open and running on a localserver:
Run `npm start cypress`
Open each file and run the tests in cypress.

### Applicable tickets?
#29 
